### PR TITLE
Parse messages for PR links and notify anyone mentioned

### DIFF
--- a/src/main/java/com/application/PRLinkRespond.java
+++ b/src/main/java/com/application/PRLinkRespond.java
@@ -106,7 +106,10 @@ public class PRLinkRespond {
 	}
 
 	private static boolean isAtMention(String text, List<String> channelMembers) {
-		return text.length() > 0 && '@' == text.charAt(0) && channelMembers.stream().anyMatch(member -> text.substring(1, text.indexOf(">")).equals(member));
+		return text.length() > 0
+			&& '@' == text.charAt(0)
+			&& text.contains(">")
+			&& channelMembers.stream().anyMatch(member -> text.substring(1, text.indexOf(">")).equals(member));
 	}
 
 	private static boolean isAtHereOrAtChannel(String text) {

--- a/src/main/java/com/application/PRLinkRespond.java
+++ b/src/main/java/com/application/PRLinkRespond.java
@@ -34,19 +34,24 @@ public class PRLinkRespond {
 		// <https://github.com/svelupillai/hackathon-slackbot-pr/pull/11|my PR>
 		String[] maybeLinks = text.split("<");
 
+		ConversationsMembersResponse channelMembersResponse = ctx.client()
+			.conversationsMembers(ConversationsMembersRequest.builder()
+				.channel(event.getChannel())
+				.build());
+
+		ConversationsInfoResponse channelInfoResponse = ctx.client()
+			.conversationsInfo(ConversationsInfoRequest.builder()
+				.channel(event.getChannel())
+				.build());
+
+		// There seems to be a bug where it can't retrieve channel info and members for DMs, so just do nothing in this case
+		if (!channelInfoResponse.isOk() || !channelMembersResponse.isOk()) {
+			return ctx.ack();
+		}
+
 		for (String word : maybeLinks) {
 			if (isGithubPRLink(word)) {
 				String justTheLink = word.substring(0, getEndOfLink(word));
-
-				ConversationsMembersResponse channelMembersResponse = ctx.client()
-					.conversationsMembers(ConversationsMembersRequest.builder()
-						.channel(event.getChannel())
-						.build());
-
-				ConversationsInfoResponse channelInfoResponse = ctx.client()
-					.conversationsInfo(ConversationsInfoRequest.builder()
-						.channel(event.getChannel())
-						.build());
 
 				for (String member: channelMembersResponse.getMembers()) {
 					UsersInfoResponse usersInfoResponse = ctx.client()

--- a/src/main/java/com/application/PRLinkRespond.java
+++ b/src/main/java/com/application/PRLinkRespond.java
@@ -1,0 +1,88 @@
+package com.application;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsInfoRequest;
+import com.slack.api.methods.request.conversations.ConversationsMembersRequest;
+import com.slack.api.methods.request.users.UsersInfoRequest;
+import com.slack.api.methods.response.conversations.ConversationsInfoResponse;
+import com.slack.api.methods.response.conversations.ConversationsMembersResponse;
+import com.slack.api.methods.response.users.UsersInfoResponse;
+import com.slack.api.model.event.MessageEvent;
+
+public class PRLinkRespond {
+
+	// Parses messages for GitHub PR links and notifies everyone in the channel
+	public static Response checkForPRLinksAndRespond(EventsApiPayload<MessageEvent> payload, EventContext ctx) throws SlackApiException, IOException {
+		MessageEvent event = payload.getEvent();
+
+		String text = event.getText();
+
+		if (text == null) {
+			return ctx.ack();
+		}
+
+		// Links in a Slack message are always surrounded by <>
+		// e.g. <https://github.com/svelupillai/hackathon-slackbot-pr/pull/11>
+		// If the link is embedded in text, it will show as:
+		// <https://github.com/svelupillai/hackathon-slackbot-pr/pull/11|my PR>
+		String[] maybeLinks = text.split("<");
+
+		for (String word : maybeLinks) {
+			if (isGithubPRLink(word)) {
+				String justTheLink = word.substring(0, getEndOfLink(word));
+
+				ConversationsMembersResponse channelMembersResponse = ctx.client()
+					.conversationsMembers(ConversationsMembersRequest.builder()
+						.channel(event.getChannel())
+						.build());
+
+				ConversationsInfoResponse channelInfoResponse = ctx.client()
+					.conversationsInfo(ConversationsInfoRequest.builder()
+						.channel(event.getChannel())
+						.build());
+
+				for (String member: channelMembersResponse.getMembers()) {
+					UsersInfoResponse usersInfoResponse = ctx.client()
+						.usersInfo(UsersInfoRequest.builder()
+							.user(event.getUser())
+							.build());
+
+					ctx.client().chatPostMessage(r -> r
+						.channel(member)
+						.text(String.format("Hey! %s just posted a PR link in #%s: %s",
+							usersInfoResponse.getUser().getRealName(),
+							channelInfoResponse.getChannel().getName(),
+							justTheLink))
+					);
+				}
+			}
+		}
+		return ctx.ack();
+	}
+
+	// matches a URL ending with >, optionally with |<text> before the >, optionally with other text after, e.g:
+	// https://github.com/svelupillai/hackathon-slackbot-pr/pull/11|This is my link text> Some other text after
+	private static final Pattern urlPattern = Pattern.compile(
+		"https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)(\\|.*)?>(.*)?",
+		Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+
+	private static boolean isGithubPRLink(String text) {
+		Matcher matcher = urlPattern.matcher(text);
+		return matcher.matches() && text.contains("pull") && text.contains("github.com");
+	}
+
+	private static int getEndOfLink(String link) {
+		if (link.contains("|")) {
+			return link.indexOf("|");
+		} else {
+			return link.indexOf(">");
+		}
+	}
+}

--- a/src/main/java/com/application/SlackApp.java
+++ b/src/main/java/com/application/SlackApp.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.slack.api.bolt.App;
+import com.slack.api.model.event.MessageEvent;
 
 @Configuration
 public class SlackApp {
@@ -56,6 +57,9 @@ public class SlackApp {
 					return ctx.ack("Invalid command: " + commandArgs[0]);
 			}
 		});
+
+		app.event(MessageEvent.class, PRLinkRespond::checkForPRLinksAndRespond);
+
 		return app;
 	}
 }


### PR DESCRIPTION
Parses all incoming messages for any channel that the bot is added to. If it sees a GitHub PR link in the message, notifies anyone mentioned in the message.

For example, if I post the message "@channel Hey please review my PR: https://github.com/svelupillai/hackathon-slackbot-pr/pull/5" in the #q2-hackathon channel will notify everyone with the message:
> Hey! Erin Benderoff just posted a PR link in #q2-hackathon: https://github.com/svelupillai/hackathon-slackbot-pr/pull/5

I wanted to also support user groups (like `@payments`, `@invoicing`, etc) but it seems user groups are only available in paid Slack so I couldn't test with it 😞 