### PR TITLE
Reminder enhancements

### DIFF
--- a/src/main/java/com/application/Constants.java
+++ b/src/main/java/com/application/Constants.java
@@ -8,6 +8,8 @@ public class Constants {
 	public static final String HELP = "HELP";
 	public static final String PING = "PING";
 	public static final String REMIND = "REMIND";
+	public static final String REMINDERS = "REMINDERS";
+	public static final String CLEAR_REMINDERS = "CLEAR_REMINDERS";
 	public static final String UNSUBSCRIBE = "UNSUBSCRIBE";
 	public static final String UNFOLLOW = "UNFOLLOW";
 	public static final String REPOS = "REPOS";

--- a/src/main/java/com/application/GithubReminder.java
+++ b/src/main/java/com/application/GithubReminder.java
@@ -20,7 +20,7 @@ public class GithubReminder {
 	public static Response remind(SlashCommandContext ctx, String userToken, String prLink, String reminderText) throws SlackApiException, IOException {
 		var logger = ctx.logger;
 		RemindersAddResponse response = ctx.client().remindersAdd(RemindersAddRequest.builder()
-			.time(reminderText) // time in seconds
+			.time(reminderText)
 			.text(String.format("Review the PR %s", prLink))
 			.token(userToken)
 			.build()

--- a/src/main/java/com/application/GithubReminder.java
+++ b/src/main/java/com/application/GithubReminder.java
@@ -1,32 +1,27 @@
 package com.application;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import com.slack.api.bolt.context.builtin.SlashCommandContext;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.reminders.RemindersAddRequest;
+import com.slack.api.methods.request.reminders.RemindersDeleteRequest;
+import com.slack.api.methods.request.reminders.RemindersListRequest;
 import com.slack.api.methods.response.reminders.RemindersAddResponse;
+import com.slack.api.methods.response.reminders.RemindersListResponse;
+import com.slack.api.model.Reminder;
 
 public class GithubReminder {
 
-	public static Response remind(SlashCommandContext ctx, String userToken, String prLink, String hours, String minutes) throws SlackApiException, IOException {
+	public static Response remind(SlashCommandContext ctx, String userToken, String prLink, String reminderText) throws SlackApiException, IOException {
 		var logger = ctx.logger;
-
-		int mins;
-		int hrs;
-
-		try {
-			hrs = Integer.parseInt(hours);
-			mins = Integer.parseInt(minutes);
-		} catch (NumberFormatException e) {
-			return ctx.ack(String.format("Error: invalid number [%s]", e.getMessage()));
-		}
-
 		RemindersAddResponse response = ctx.client().remindersAdd(RemindersAddRequest.builder()
-			.time(String.valueOf(hrs * 60 * 60 + mins * 60)) // time in seconds
-			.text(String.format("Reminder to review PR %s!", prLink))
+			.time(reminderText) // time in seconds
+			.text(String.format("Review the PR %s", prLink))
 			.token(userToken)
 			.build()
 		);
@@ -36,7 +31,64 @@ public class GithubReminder {
 			return ctx.ack("Error setting reminder");
 		}
 
-		Date reminderDate = new Date ((long) response.getReminder().getTime() * 1000);
-		return ctx.ack(String.format("You will be reminded to review the PR %s on %s", prLink, reminderDate));
+		if (response.getReminder().isRecurring()) {
+			return ctx.ack(String.format("You will be reminded to review the PR %s %s", prLink, reminderText));
+		} else if (response.getReminder().getTime() != null) {
+			Date reminderDate = getDateFromTimestamp(response.getReminder().getTime());
+			return ctx.ack(String.format("You will be reminded to review the PR %s on %s", prLink, reminderDate));
+		}
+
+		return ctx.ack(String.format("You will be reminded to review the PR %s %s", prLink, reminderText));
+	}
+
+	public static Response listReminders(SlashCommandContext ctx, String userToken) throws SlackApiException, IOException {
+		RemindersListResponse remindersListResponse = ctx.client().remindersList(RemindersListRequest.builder().token(userToken).build());
+
+		if (!remindersListResponse.isOk()) {
+			return ctx.ack("Error getting reminders");
+		}
+
+		if (remindersListResponse.getReminders().isEmpty()) {
+			return ctx.ack("You have no reminders set up.");
+		}
+
+		List<String> reminders = new ArrayList<>();
+
+		for (Reminder reminder : remindersListResponse.getReminders()) {
+			if (!reminder.isRecurring()) {
+				String reminderText = String.format("%s on %s", reminder.getText(), getDateFromTimestamp(reminder.getTime()));
+				if (reminder.getCompleteTs() > 0) {
+					reminderText += String.format(" *Marked complete on %s*", getDateFromTimestamp(reminder.getCompleteTs()));
+				}
+				reminders.add(reminderText);
+			} else {
+				reminders.add(String.format("Recurring reminder: %s", reminder.getText()));
+			}
+		}
+
+		return ctx.ack("Here are your PR review reminders:\n" + String.join("\n", reminders));
+	}
+
+	public static Response deleteAllReminders(SlashCommandContext ctx, String userToken) throws SlackApiException, IOException {
+		RemindersListResponse remindersListResponse = ctx.client().remindersList(RemindersListRequest.builder().token(userToken).build());
+
+		if (!remindersListResponse.isOk()) {
+			return ctx.ack("Error getting reminders");
+		}
+
+		if (remindersListResponse.getReminders().isEmpty()) {
+			return ctx.ack("You have no reminders set up.");
+		}
+
+		for (Reminder reminder : remindersListResponse.getReminders()) {
+			ctx.client().remindersDelete(RemindersDeleteRequest.builder()
+				.reminder(reminder.getId())
+				.token(userToken).build());
+		}
+		return ctx.ack("Successfully cleared reminders");
+	}
+
+	private static Date getDateFromTimestamp(Integer timestamp) {
+		return new Date ((long) timestamp * 1000);
 	}
 }

--- a/src/main/java/com/application/SlackApp.java
+++ b/src/main/java/com/application/SlackApp.java
@@ -1,5 +1,7 @@
 package com.application;
 
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,7 +15,7 @@ public class SlackApp {
 
 		final String USER_TOKEN = System.getenv("SLACK_USER_TOKEN");
 
-		app.command("/prpal", (req, ctx) -> {
+		app.command("/prpal2", (req, ctx) -> {
 			String payload = req.getPayload().getText();
 			String slackUserId = req.getPayload().getUserId();
 
@@ -50,10 +52,14 @@ public class SlackApp {
 					}
 					return ctx.ack();
 				case Constants.REMIND:
-					if (commandArgs.length < 4) {
-						return ctx.ack("Error: Must provide command in the format: remind <PR_LINK> <hours> <minutes>");
+					if (commandArgs.length < 3) {
+						return ctx.ack("Error: Must provide command in the format: remind <pr_link> <reminder_text>");
 					}
-					return GithubReminder.remind(ctx, USER_TOKEN, commandArgs[1], commandArgs[2], commandArgs[3]);
+					return GithubReminder.remind(ctx, USER_TOKEN, commandArgs[1], String.join(" ", Arrays.copyOfRange(commandArgs, 2, commandArgs.length)));
+				case Constants.REMINDERS:
+					return GithubReminder.listReminders(ctx, USER_TOKEN);
+				case Constants.CLEAR_REMINDERS:
+					return GithubReminder.deleteAllReminders(ctx, USER_TOKEN);
 				case Constants.REPOS:
 					return GithubSubscribe.getSubscribedRepos(ctx, req.getPayload().getUserId());
 				case Constants.USERS:

--- a/src/main/java/com/application/SlackApp.java
+++ b/src/main/java/com/application/SlackApp.java
@@ -15,7 +15,7 @@ public class SlackApp {
 
 		final String USER_TOKEN = System.getenv("SLACK_USER_TOKEN");
 
-		app.command("/prpal2", (req, ctx) -> {
+		app.command("/prpal", (req, ctx) -> {
 			String payload = req.getPayload().getText();
 			String slackUserId = req.getPayload().getUserId();
 


### PR DESCRIPTION
The remind command is now in the format:
`/prpal remind <PR_LINK> <reminder_text>` 
where reminder_text is your reminder in natural language (e.g. in 5 minutes). The Slack API is able to process this and figure out the reminder (in most cases, hopefully)

Also added method to list all reminders: `/prpal reminders`
Example response:
![image](https://user-images.githubusercontent.com/14361988/119997595-e05e9e00-bf9d-11eb-9a07-12fb932cd2ca.png)

And method to clear all reminders: `/prpal clear_reminders`